### PR TITLE
avoid changing directory in shell script

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -124,7 +124,13 @@ lazy val buildSettings = Seq(
   resourceGenerators in Compile += (listDocResources in CheeDoc).taskValue,
   resourceGenerators in Compile += (fetchResources in Compile).taskValue,
   sourceGenerators in Compile += (genDocInfo in CheeDoc).taskValue,
-  sourceGenerators in Compile += (resourceInfo in Compile).taskValue.map(f => Seq(f))
+  sourceGenerators in Compile += (resourceInfo in Compile).taskValue.map(f => Seq(f)),
+  packageOptions in (Compile, packageBin) += Package.ManifestAttributes(
+    "Class-Path" -> Attributed.data((fullClasspath in Runtime).value).
+      withFilter(_.isFile).
+      map(_.getName).
+      mkString(" ")
+  )
 )
 
 addCommandAlias("run-all-tests", ";genDocResources;test;itTest:test")

--- a/project/ScriptPlugin.scala
+++ b/project/ScriptPlugin.scala
@@ -30,14 +30,14 @@ object ScriptPlugin extends AutoPlugin {
     `gen-zip` in Compile := genZipImpl.value
   )
 
-  def makeScript(sourceDir: File, classpath: String, shebang: String, java: String, javaOpts: String, cdtohere: Boolean = false): String = {
+  def makeScript(sourceDir: File, classpath: Option[String], jarfile: Option[String], shebang: String, java: String, javaOpts: String): String = {
     val template = Template(sourceDir / "shell" / "chee")
     template.render(Map(
-      "cdtohere" -> cdtohere,
       "shebang" -> shebang,
       "options" -> javaOpts,
       "javabin" -> java,
-      "classpath" -> classpath
+      "classpath" -> classpath.orNull,
+      "jarfile" -> jarfile.orNull
     ))
   }
 
@@ -55,7 +55,8 @@ object ScriptPlugin extends AutoPlugin {
     val out = target.value / "bin" / "chee"
     val body = makeScript(
       sourceDirectory.value,
-      Attributed.data((fullClasspath in Runtime).value).mkString(java.io.File.pathSeparator),
+      Some(Attributed.data((fullClasspath in Runtime).value).mkString(java.io.File.pathSeparator)),
+      None,
       (shebang in script).value,
       (javaBin in script).value,
       (javaOptions in script).value.mkString(" "))
@@ -77,11 +78,11 @@ object ScriptPlugin extends AutoPlugin {
     }
     val body = makeScript(
       sourceDirectory.value,
-      libs.mkString(java.io.File.pathSeparator),
+      None,
+      Some(("lib" + java.io.File.separator + (packageBin in Compile).value.getName)),
       (shebang in script).value,
       (javaBin in script).value,
-      (javaOptions in script).value.mkString(" "),
-      true)
+      (javaOptions in script).value.mkString(" "))
 
     IO.write(zipDir / "chee", body)
     setExecutable(zipDir / "chee")

--- a/readme.org
+++ b/readme.org
@@ -110,6 +110,7 @@ Chee is distributed under the [[http://www.gnu.org/licenses/gpl-3.0.html][GPLv3]
 ** 0.3.0 (development)
 
 - add command ~meta tags~ to list all tags in use
+- fixes bug (#4) in `chee` shell script for repository mode
 
 ** 0.2.0
 

--- a/src/main/shell/chee
+++ b/src/main/shell/chee
@@ -1,5 +1,9 @@
 #!<shebang>
 
-<if(cdtohere)>cd $(dirname $(readlink -e $0))<endif>
-
+<if(jarfile)>
+libdir=$(dirname $(readlink -e $0))
+<javabin> -jar <options> $CHEE_OPTS "$libdir/<jarfile>" "$@"
+<endif>
+<if(classpath)>
 <javabin> -cp <classpath> <options> $CHEE_OPTS chee.cli.Main "$@"
+<endif>


### PR DESCRIPTION
Since chee uses current working directory to determine repository mode,
it must not be changed by `chee` shell script.

When building the final jar, the classpath is included in the MANIFEST
file, so that it can be run if it is put into a directory containing the
dependency jars. The `chee` shell script then only needs to run this
jar.

This should fix #4.